### PR TITLE
Implement LaunchpadDetailRepositoryImpl unit test

### DIFF
--- a/solutions/devsprint-haldny-santos-2/app/build.gradle
+++ b/solutions/devsprint-haldny-santos-2/app/build.gradle
@@ -105,7 +105,6 @@ dependencies {
     implementation "io.insert-koin:koin-core:$koin_version"
     implementation "io.insert-koin:koin-android:$koin_version"
 
-
     // Fragment KTX
     implementation 'androidx.fragment:fragment-ktx:1.4.0'
 }

--- a/solutions/devsprint-haldny-santos-2/app/src/test/java/com/devpass/spaceapp/Fakes.kt
+++ b/solutions/devsprint-haldny-santos-2/app/src/test/java/com/devpass/spaceapp/Fakes.kt
@@ -6,7 +6,10 @@ import com.devpass.spaceapp.data.api.response.Links
 import com.devpass.spaceapp.data.api.response.OptionsRequest
 import com.devpass.spaceapp.data.api.response.Patch
 import com.devpass.spaceapp.data.api.response.QueryParams
+import com.devpass.spaceapp.data.api.response.LaunchpadDetailResponse
 import com.devpass.spaceapp.model.Launch
+import com.devpass.spaceapp.model.LaunchpadDetail
+
 
 val fakeQueryParams = QueryParams(OptionsRequest(20))
 
@@ -44,4 +47,26 @@ val fakeLaunch = Launch(
     rocketId = "",
     details = "",
     launchpadId = ""
+)
+
+val fakeLaunchpadDetailResponse = LaunchpadDetailResponse(
+    id = "id",
+    name = "VAFB SLC 4E",
+    locality = "Vandenberg Air Force Base",
+    region = "California",
+    latitude = 34.74203,
+    longitude = -120.57244,
+    launchAttempts = 15,
+    launchSuccesses = 15
+)
+
+val fakeLaunchpadDetail = LaunchpadDetail(
+    id = "id",
+    name = "VAFB SLC 4E",
+    locality = "Vandenberg Air Force Base",
+    region = "California",
+    latitude = 34.74203,
+    longitude = -120.57244,
+    launchAttempts = 15,
+    launchSuccesses = 15
 )

--- a/solutions/devsprint-haldny-santos-2/app/src/test/java/com/devpass/spaceapp/repository/launchpad/LaunchpadDetailRepositoryImplTest.kt
+++ b/solutions/devsprint-haldny-santos-2/app/src/test/java/com/devpass/spaceapp/repository/launchpad/LaunchpadDetailRepositoryImplTest.kt
@@ -1,0 +1,71 @@
+package com.devpass.spaceapp.repository.launchpad
+
+import com.devpass.spaceapp.data.api.SpaceXAPIService
+import com.devpass.spaceapp.fakeLaunchpadDetail
+import com.devpass.spaceapp.fakeLaunchpadDetailResponse
+import com.devpass.spaceapp.utils.NetworkResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class LaunchpadDetailRepositoryImplTest {
+
+    private val api = mockk<SpaceXAPIService>(relaxed = true)
+    private val mapper = mockk<LaunchpadDetailMapper>(relaxed = true)
+    private val repository = LaunchpadDetailRepositoryImpl(api, mapper)
+
+    @Test
+    fun `GIVEN LaunchpadDetailResponse WHEN fetchLaunchpad is called THEN return a NetworkResult success`() {
+         runTest {
+             //GIVEN
+             val launchpadDetailResponse = fakeLaunchpadDetailResponse
+             val launchpadDetail = fakeLaunchpadDetail
+
+             every {
+                 mapper.transformToLaunchpadModel(launchpadDetailResponse)
+             } returns launchpadDetail
+
+             val expected = NetworkResult.Success(launchpadDetail)
+
+             coEvery {
+                 api.fetchLaunchpadDetails(ID)
+             } returns launchpadDetailResponse
+
+             //WHEN
+             val result = repository.fetchLaunchpad(ID)
+
+             //THEN
+             coVerify { api.fetchLaunchpadDetails(ID) }
+             assertEquals(expected, result)
+         }
+    }
+
+    @Test(expected = Exception::class)
+    fun `GIVEN LaunchpadDetailResponse WHEN fetchLaunchpad is called THEN return a NetworkResult error`() {
+        runTest {
+            //GIVEN
+            val expected = NetworkResult.Error<Any>(RuntimeException())
+
+            coEvery {
+                api.fetchLaunchpadDetails(ID)
+            } throws RuntimeException()
+
+            //WHEN
+            val result = repository.fetchLaunchpad(ID)
+
+            //THEN
+            coVerify { api.fetchLaunchpadDetails(ID) }
+            assertEquals(expected, result)
+        }
+    }
+
+    companion object {
+        const val ID = "ANY_ID"
+    }
+}


### PR DESCRIPTION
- Inclui nas dependências do app as bibliotecas Mockk e Kotlin Coroutines Test.
- Implementa teste unitário para a classe LaunchpadDetailRepositoryImpl.kt