### PR TITLE
RocketDetailsActivity Rocket tab test

### DIFF
--- a/solutions/devsprint-haldny-santos-2/app/src/androidTest/java/com/devpass/spaceapp/presentation/launch/LaunchActivityTest.kt
+++ b/solutions/devsprint-haldny-santos-2/app/src/androidTest/java/com/devpass/spaceapp/presentation/launch/LaunchActivityTest.kt
@@ -6,6 +6,7 @@ import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assert
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaListInteractions.clickListItem
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions.sleep
+import com.adevinta.android.barista.interaction.BaristaViewPagerInteractions.swipeViewPagerForward
 import com.devpass.spaceapp.R
 import com.devpass.spaceapp.presentation.launch_list.LaunchListActivity
 import org.junit.Rule
@@ -19,12 +20,37 @@ class LaunchActivityTest {
     val activityRule = ActivityScenarioRule(LaunchListActivity::class.java)
 
     @Test
-    fun barista_givenLaunchActivityWhenClickOnViewMoreThenGoToLaunchpadDetailsActivityWithRocketDataFilled() {
-        sleep(5000L)
+    fun givenLaunchActivityWhenClickOnViewMoreThenGoToLaunchpadDetailsActivityWithRocketDataFilled() {
+        goToLastItem()
+
+        swipeViewPagerForward()
+        swipeViewPagerForward()
+        clickOn("VIEW MORE")
+
+        assertDisplayed(R.id.map)
+    }
+
+    @Test
+    fun givenLaunchActivityWhenClickOnRocketCardThenGoToRocketDetailsActivityWithRocketDataFilled() {
+        goToLastItem()
+
+        swipeViewPagerForward()
+        clickOn(R.id.rocket_card_view)
+
+        sleep(LOAD_DETAILS_DELAY)
+
+        assertDisplayed(R.id.textViewNameRocketDetails)
+        assertDisplayed(R.id.imageViewRocketDetails)
+    }
+
+    private fun goToLastItem() {
+        sleep(INITIAL_LOADING_DELAY)
         clickListItem(R.id.rv_launches, 19)
         assertDisplayed(R.id.tvTitle, "DSCOVR")
-        clickOn("LAUNCHPAD")
-        clickOn("VIEW MORE")
-        assertDisplayed(R.id.map)
+    }
+
+    private companion object {
+        const val INITIAL_LOADING_DELAY = 5000L
+        const val LOAD_DETAILS_DELAY = 2000L
     }
 }

--- a/solutions/devsprint-haldny-santos-2/app/src/main/java/com/devpass/spaceapp/presentation/launch/RocketFragment.kt
+++ b/solutions/devsprint-haldny-santos-2/app/src/main/java/com/devpass/spaceapp/presentation/launch/RocketFragment.kt
@@ -39,7 +39,7 @@ class RocketFragment : Fragment() {
         }
 
         with(binding) {
-            cardView.setOnClickListener {
+            rocketCardView.setOnClickListener {
                 val intent = Intent(requireContext(), RocketDetailsActivity::class.java).apply {
                     putExtra(ARG_ROCKET, rocketId)
                 }

--- a/solutions/devsprint-haldny-santos-2/app/src/main/res/layout/fragment_rocket.xml
+++ b/solutions/devsprint-haldny-santos-2/app/src/main/res/layout/fragment_rocket.xml
@@ -7,7 +7,7 @@
     tools:context=".presentation.launch.RocketFragment">
 
     <androidx.cardview.widget.CardView
-        android:id="@+id/cardView"
+        android:id="@+id/rocket_card_view"
         android:layout_width="@dimen/width_card"
         android:layout_height="@dimen/height_card_rocket"
         android:layout_gravity="center_horizontal"


### PR DESCRIPTION
- Foi implementado teste para escolher um item, ir para a aba "ROCKET" e clicar no card para ir aos detalhes;
- Foi corrigido o teste para ir a aba "LAUNCHPAD" que não estava funcionando.